### PR TITLE
credentials: Use cross-platform credentials.toml instead of Unix-specific .env files. 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,0 @@
-export GITHUB_USERNAME=((your github username))
-export GITHUB_ACCESS_TOKEN=((your github access token))
-# export GITEA_BASE_URL=((gitea.example.com))
-# export GITEA_USERNAME=((your gitea username))
-# export GITEA_ACCESS_TOKEN=((your gitea access token))

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ vls.log
 
 # Enviroment files
 *.env
-
+*.toml

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ vls.log
 # Enviroment files
 *.env
 *.toml
+
+# JetBrains Files
+.idea

--- a/README.md
+++ b/README.md
@@ -93,34 +93,15 @@ klonol -h
 
 ## Usage
 
-### Setting the environment variables
+### Setting the variables
 
-For GitHub the following variables need to be set.
-
+The following variables need to be set in a file called `credentials.toml`.
 | Name                | Description                                                                              | Compulsory |
 | ------------------- | ---------------------------------------------------------------------------------------- | ---------- |
-| GITHUB_USERNAME     | The username whose repositories are to be queried                                        | Yes        |
-| GITHUB_ACCESS_TOKEN | The personal access token generated previously                                           | Yes        |
-| GITHUB_BASE_URL     | The base domain to be used to test SSH and make API calls from. Defaults to `github.com` | No         |
+| USERNAME            | The github or gittea username whose repositories are to be queried                       | Yes        |
+| ACCESS_TOKEN        | The personal access token generated previously                                           | Yes        |
+| BASE_URL            | The base domain to be used to test SSH and make API calls from. Defaults to `github.com` | No         |
 
-For Gitea the following need to be set:
-
-| Name               | Description                                                                                  | Compulsory |
-| ------------------ | -------------------------------------------------------------------------------------------- | ---------- |
-| GITEA_USERNAME     | The username whose repositories are to be queried                                            | Yes        |
-| GITEA_ACCESS_TOKEN | The personal access token generated previously                                               | Yes        |
-| GITEA_BASE_URL     | The domain where the Gitea instance is hosted. Do not include the protocol (e.g. `https://`) | Yes        |
-
-For Unix-like systems, copy the `.env.sample` file, fill in the appropriate
-values, comment out the ones you don't need. Then run the following to add
-the required variables to your session:
-
-```bash
-source .env
-```
-
-For Windows, you need to set the environment variables manually (for now).
-If you want to make it analogous to the Unix way, please contribute a solution.
 
 ### Running klonol
 
@@ -156,11 +137,12 @@ klonol --help
 
 
 # Options:
-#   -p, --provider <string>   git provider to use
-#   -a, --action <string>     action to perform
-#   -v, --verbose             enable verbose output
-#   -h, --help                display this help and exit
-#   --version                 output version information and exit
+#   -p, --provider <string>    git provider to use
+#   -c, --credentials <string> path to credentials.toml file (default is ./credentials.toml)
+#   -a, --action <string>      action to perform
+#   -v, --verbose              enable verbose output
+#   -h, --help                 display this help and exit
+#   --version                  output version information and exit
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
+<!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
 <h1><em>klonol</em></h1>
 
 [vlang.io](https://vlang.io) | [hungrybluedev](https://hungrybluedev.in/)
 
 </div>
+<!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
 
-[![CI][workflowbadge]][workflowurl]
-[![License: MIT][licensebadge]][licenseurl]
-[![Git Latest Tag][gittagbadge]][gittagurl]
+[![CI][workflow_badge]][workflow_url]
+[![License: MIT][license_badge]][license_url]
+[![Git Latest Tag][git_tag_badge]][git_tag_url]
 
 </div>
 
@@ -23,13 +25,15 @@ authenticated user).
    to the authenticated user.
 3. You can list all available repositories, clone them, or run `git pull`
    on existing clones. It uses the user's SSH key to clone.
+4. Cross-platform! We've switched to using TOML for storing credentials and
+   have tested this project extensively on Windows as well.
 
 ## Motivation
 
 I self-host my Gitea instance. It contains several private repositories. There
 are some instances where I need to upgrade the server or perform some
 maintenance. Although I use [Docker Compose](https://docs.docker.com/compose/)
-with mounted volumes to manage the Gitea instance, there may be times where
+with mounted volumes to manage the Gitea instance, there may be times when
 data retention is not possible. I need to restart my service from scratch. In
 order to help with these "from-scratch" scenarios, I wrote this tool.
 
@@ -45,7 +49,8 @@ git server in peace.
 2. You must have a GitHub or Gitea account.
 3. [Add an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
    to your appropriate account.
-4. Generate an [_personal access token_](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+4. Generate a [_personal access
+   token_](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
    with the minimum scope of `repo` (to allow viewing private repositories)
    and set an expiration of 7 days or the lowest possible. Regenerate this
    key when it expires.
@@ -76,6 +81,10 @@ v build.vsh
 
 The optimized `klonol` binary is saved in the `bin` subdirectory.
 
+**Note:** If you are working on _klonol_ locally and want faster builds for quicker
+prototyping, use `v build.vsh -fast` to use TCC and build an unoptimised executable
+quickly.
+
 **Step 3:** Add to `PATH`
 
 Add the `bin` subdirectory to your `PATH`. You can edit your `~/.bashrc` file
@@ -96,20 +105,31 @@ klonol -h
 ### Setting the variables
 
 The following variables need to be set in a file called `credentials.toml`.
-both github and gittea will use these same variables, so if you want to have github
-and gittea credentials saved in the same file at the same time, simply comment out
-the ones you don't want to use.
-| Name                | Description                                                                              | Compulsory |
-| ------------------- | ---------------------------------------------------------------------------------------- | ---------- |
-| USERNAME            | The github or gittea username whose repositories are to be queried                       | Yes        |
-| ACCESS_TOKEN        | The personal access token generated previously                                           | Yes        |
-| BASE_URL            | The base domain to be used to test SSH and make API calls from. Defaults to `github.com` | No         |
 
+| Name           | Description                                                                              | Compulsory |
+|----------------|------------------------------------------------------------------------------------------|------------|
+| `username`     | The GitHub or Gitea username whose repositories are to be queried                        | Yes        |
+| `access_token` | The personal access token generated previously                                           | Yes        |
+| `base_url`     | The base domain to be used to test SSH and make API calls from. Defaults to `github.com` | For Gitea  |
+
+A sample `credentials.toml` file will look like this:
+
+```toml
+[github]
+username = "your_username"
+access_token = "XYZXYZ"
+
+[gitea]
+base_url = "git.yourdomain.com"
+username = "your_username"
+access_token = "XYZXYZ"
+
+```
 
 ### Running klonol
 
-Once the environment variables have been set, klonol will retrieve the
-relevant information automatically.
+Once the variables have been set, klonol will retrieve the relevant
+information automatically.
 
 **Help Information**
 
@@ -117,7 +137,7 @@ relevant information automatically.
 # Get the version
 klonol --version
 # output:
-# klonol 0.3.x
+# klonol 0.5.x
 
 
 # Get detailed usage information
@@ -125,28 +145,28 @@ klonol -h
 # OR
 klonol --help
 # output:
-# klonol 0.3.x
+# klonol 0.5.x
 # -----------------------------------------------
 # Usage: klonol [options] [ARGS]
-
+#
 # Description: A CLI tool to "clone all" repositories belonging to you.
-
+#
 # klonol requires Access Tokens to work properly. Refer to README for more
 # information. It retrieves information about ALL available repositories
 # belonging to the authenticated user. Both public and private.
-
+#
 # Please follow safety precautions when storing access tokens, and read
 # the instructions in README carefully.
-
-
+#
+#
 # Options:
-#   -p, --provider <string>    git provider to use
-#   -c, --credentials <string> path to credentials.toml file (default is ./credentials.toml)
-#   -a, --action <string>      action to perform
-#   -v, --verbose              enable verbose output
-#   -h, --help                 display this help and exit
-#   --version                  output version information and exit
-
+#   -p, --provider <string>   git provider to use (default is github)
+#   -c, --credentials <string>
+#                             path to credentials.toml file (default is ./credentials.toml)
+#   -a, --action <string>     action to perform [list, clone, pull]
+#   -v, --verbose             enable verbose output
+#   -h, --help                display this help and exit
+#   --version                 output version information and exit
 ```
 
 **Sample usage flow for GitHub**
@@ -154,6 +174,9 @@ klonol --help
 ```bash
 # Navigate to a directory to store all the repositories in
 cd ~/Backups/GitHub
+
+# Make sure you have the proper 'credentials.toml' file in the directory
+nano credentials.toml
 
 # List all available repositories
 klonol
@@ -173,6 +196,9 @@ klonol -a pull
 ```bash
 # Navigate to a directory to store all the repositories in
 cd ~/Backups/Gitea
+
+# Make sure you have the proper 'credentials.toml' file in the directory
+nano credentials.toml
 
 # List all available repositories
 klonol --provider gitea
@@ -202,9 +228,26 @@ klonol is already added to PATH.
 
 This project is distributed under the [MIT License](LICENSE).
 
-[workflowbadge]: https://github.com/hungrybluedev/klonol/actions/workflows/ci.yml/badge.svg
-[licensebadge]: https://img.shields.io/badge/License-MIT-blue.svg
-[workflowurl]: https://github.com/hungrybluedev/klonol/actions/workflows/ci.yml
-[licenseurl]: https://github.com/hungrybluedev/klonol/blob/main/LICENSE
-[gittagurl]: https://github.com/hungrybluedev/klonol/tags
-[gittagbadge]: https://img.shields.io/github/v/tag/hungrybluedev/klonol?color=purple&include_prereleases&sort=semver
+[workflow_badge]: https://github.com/hungrybluedev/klonol/actions/workflows/ci.yml/badge.svg
+
+[license_badge]: https://img.shields.io/badge/License-MIT-blue.svg
+
+[workflow_url]: https://github.com/hungrybluedev/klonol/actions/workflows/ci.yml
+
+[license_url]: https://github.com/hungrybluedev/klonol/blob/main/LICENSE
+
+[git_tag_url]: https://github.com/hungrybluedev/klonol/tags
+
+[git_tag_badge]: https://img.shields.io/github/v/tag/hungrybluedev/klonol?color=purple&include_prereleases&sort=semver
+
+## Acknowledgements
+
+ - Thanks to [A1ex-N][a1ex_n] for contributing the [idea][toml_idea] and
+[initial code][toml_pr] for supporting cross-platform TOML in favour of
+unix-specific ENV!
+
+[a1ex_n]: https://github.com/A1ex-N
+
+[toml_idea]: https://github.com/hungrybluedev/klonol/issues/1
+
+[toml_pr]: https://github.com/hungrybluedev/klonol/pull/2

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ klonol -h
 ### Setting the variables
 
 The following variables need to be set in a file called `credentials.toml`.
+both github and gittea will use these same variables, so if you want to have github
+and gittea credentials saved in the same file at the same time, simply comment out
+the ones you don't want to use.
 | Name                | Description                                                                              | Compulsory |
 | ------------------- | ---------------------------------------------------------------------------------------- | ---------- |
 | USERNAME            | The github or gittea username whose repositories are to be queried                       | Yes        |

--- a/build.vsh
+++ b/build.vsh
@@ -7,9 +7,9 @@ mkdir('bin')!
 println('Done creating "bin" directory.')
 
 println('\nChecking if everything is formatted correctly...')
-execute_or_panic('v fmt -verify .')
+execute_or_panic('${@VEXE} fmt -verify .')
 println('Done checking formatting.')
 
 println('\nCompiling and building executable...')
-execute_or_panic('v -prod . -o bin/klonol')
+execute_or_panic('${@VEXE} -prod . -o bin/klonol')
 println('Done compiling and placing executable in "bin".')

--- a/build.vsh
+++ b/build.vsh
@@ -1,3 +1,10 @@
+// Make compilation on windows faster
+compiler := $if windows {
+	'msvc'
+} $else {
+	'cc'
+}
+
 println('Removing old artifacts...')
 rmdir_all('bin') or {}
 println('Done removing "bin" directory.')
@@ -7,9 +14,9 @@ mkdir('bin')!
 println('Done creating "bin" directory.')
 
 println('\nChecking if everything is formatted correctly...')
-execute_or_panic('${@VEXE} fmt -verify .')
+execute_or_panic('${quoted_path(@VEXE)} fmt -verify .')
 println('Done checking formatting.')
 
 println('\nCompiling and building executable...')
-execute_or_panic('${@VEXE} -prod . -o bin/klonol')
+execute_or_panic('${quoted_path(@VEXE)} -cc "${compiler}" -prod . -o bin/klonol')
 println('Done compiling and placing executable in "bin".')

--- a/build.vsh
+++ b/build.vsh
@@ -1,9 +1,4 @@
-// Make compilation on windows faster
-compiler := $if windows {
-	'msvc'
-} $else {
-	'cc'
-}
+import os
 
 println('Removing old artifacts...')
 rmdir_all('bin') or {}
@@ -18,5 +13,17 @@ execute_or_panic('${quoted_path(@VEXE)} fmt -verify .')
 println('Done checking formatting.')
 
 println('\nCompiling and building executable...')
-execute_or_panic('${quoted_path(@VEXE)} -cc "${compiler}" -prod . -o bin/klonol')
+
+if '-fast' in os.args {
+	execute_or_panic('${quoted_path(@VEXE)} . -o bin/klonol')
+} else {
+	// Make compilation on windows faster
+	compiler := $if windows {
+		'msvc'
+	} $else {
+		'cc'
+	}
+	execute_or_panic('${quoted_path(@VEXE)} -cc "${compiler}" -prod . -o bin/klonol')
+}
+
 println('Done compiling and placing executable in "bin".')

--- a/common/types.v
+++ b/common/types.v
@@ -5,8 +5,12 @@ import x.json2
 pub struct Credentials {
 pub:
 	base_url     string = 'github.com'
-	username     string
+	username     string = 'unset value'
 	access_token string = 'unset value'
+}
+
+pub fn (c Credentials) to_toml() string {
+	return 'ACCESS_TOKEN="${c.access_token}"\nBASE_URL="${c.base_url}"\nUSERNAME="${c.username}"'
 }
 
 pub struct Repository {

--- a/common/types.v
+++ b/common/types.v
@@ -5,8 +5,8 @@ import x.json2
 pub struct Credentials {
 pub:
 	base_url     string = 'github.com'
-	username     string = 'unset value'
-	access_token string = 'unset value'
+	username     string = 'unset_value'
+	access_token string = 'unset_value'
 }
 
 pub fn (c Credentials) to_toml() string {

--- a/common/types.v
+++ b/common/types.v
@@ -1,16 +1,41 @@
 module common
 
 import x.json2
+import strings
 
-pub struct Credentials {
-pub:
-	base_url     string = 'github.com'
-	username     string = 'unset_value'
-	access_token string = 'unset_value'
+pub enum Provider {
+	github
+	gitea
 }
 
-pub fn (c Credentials) to_toml() string {
-	return 'ACCESS_TOKEN="${c.access_token}"\nBASE_URL="${c.base_url}"\nUSERNAME="${c.username}"'
+pub struct CredentialFile {
+pub:
+	credentials []Credential
+}
+
+pub fn (file CredentialFile) to_toml() string {
+	mut builder := strings.new_builder(128)
+	for cred in file.credentials {
+		builder.write_string(cred.to_toml())
+	}
+	return builder.str()
+}
+
+pub struct Credential {
+pub:
+	provider     Provider [required]
+	base_url     string = 'github.com'
+	username     string   [required]
+	access_token string   [required]
+}
+
+fn (c Credential) to_toml() string {
+	return '
+[${c.provider.str()}]
+base_url: ${c.base_url}
+username: ${c.username}
+access_token: ${c.access_token}
+'
 }
 
 pub struct Repository {

--- a/credentials.v
+++ b/credentials.v
@@ -30,7 +30,7 @@ fn load_config(path string) ?common.Credentials {
 	}
 
 	return common.Credentials{
-		base_url: creds.value('BASE_URL').string()
+		base_url: (creds.value_opt('BASE_URL') or { 'github.com' }).string()
 		username: creds.value('USERNAME').string()
 		access_token: creds.value('ACCESS_TOKEN').string()
 	}

--- a/credentials.v
+++ b/credentials.v
@@ -4,20 +4,24 @@ import common
 import toml
 import os
 
-
 fn create_default_config(path string) ?common.Credentials {
-	if os.exists(path) && os.file_size(path) != 0 { return none }
+	if os.exists(path) && os.file_size(path) != 0 {
+		return none
+	}
 
 	creds := common.Credentials{}
-	os.write_file(path, toml.encode(creds)) or { return error('Cannot write default config to "${path}"') }
+	os.write_file(path, toml.encode(creds)) or {
+		return error('Cannot write default config to "${path}"')
+	}
 	return creds
 }
 
 fn load_config(path string) ?common.Credentials {
 	if !os.exists(path) {
 		return create_default_config(path) or {
-		eprintln(err)
-		exit(1)}
+			eprintln(err)
+			exit(1)
+		}
 	}
 
 	creds := toml.parse_file(path) or {
@@ -25,9 +29,9 @@ fn load_config(path string) ?common.Credentials {
 		exit(1)
 	}
 
-	return common.Credentials {
-		base_url: creds.value('BASE_URL').string(),
-		username: creds.value('USERNAME').string(),
+	return common.Credentials{
+		base_url: creds.value('BASE_URL').string()
+		username: creds.value('USERNAME').string()
 		access_token: creds.value('ACCESS_TOKEN').string()
 	}
 }
@@ -40,7 +44,10 @@ README.md for more instructions.\n')
 }
 
 fn get_credentials_for(provider Provider, path string) !common.Credentials {
-	credentials := load_config(path) or { eprintln(err) exit(1) }
+	credentials := load_config(path) or {
+		eprintln(err)
+		exit(1)
+	}
 	base_url := credentials.base_url
 
 	if base_url.contains('http') {
@@ -68,7 +75,7 @@ fn get_credentials_for(provider Provider, path string) !common.Credentials {
 
 	token_is_valid := match provider {
 		.github { common.is_access_token_valid(access_token, 'https://api.github.com/user/issues') }
-		.gitea  { common.is_access_token_valid(access_token, 'https://${base_url}/api/v1/user?access_token=${access_token}') }
+		.gitea { common.is_access_token_valid(access_token, 'https://${base_url}/api/v1/user?access_token=${access_token}') }
 	}
 
 	if !token_is_valid {

--- a/credentials.v
+++ b/credentials.v
@@ -16,8 +16,8 @@ fn create_default_config(path string) ?common.Credentials {
 	return creds
 }
 
-fn get_value_or_set_default(creds toml.Doc, value string, default string) string {
-	retrieved_value := (creds.value_opt(value) or { default }).string()
+fn get_value_or_set_default(creds toml.Doc, key string, default string) string {
+	retrieved_value := (creds.value_opt(key) or { default }).string()
 	if retrieved_value == '' {
 		return default
 	}

--- a/credentials.v
+++ b/credentials.v
@@ -16,6 +16,14 @@ fn create_default_config(path string) ?common.Credentials {
 	return creds
 }
 
+fn get_value_or_set_default(creds toml.Doc, value string, default string) string {
+	retrieved_value := (creds.value_opt(value) or { default }).string()
+	if retrieved_value == '' {
+		return default
+	}
+	return retrieved_value
+}
+
 fn load_config(path string) ?common.Credentials {
 	if !os.exists(path) {
 		return create_default_config(path) or {
@@ -30,16 +38,16 @@ fn load_config(path string) ?common.Credentials {
 	}
 
 	return common.Credentials{
-		base_url: (creds.value_opt('BASE_URL') or { 'github.com' }).string()
-		username: creds.value('USERNAME').string()
-		access_token: creds.value('ACCESS_TOKEN').string()
+		base_url: get_value_or_set_default(creds, 'BASE_URL', 'github.com')
+		username: get_value_or_set_default(creds, 'USERNAME', 'unset_value')
+		access_token: get_value_or_set_default(creds, 'ACCESS_TOKEN', 'unset_value')
 	}
 }
 
 fn display_unprotected_access_token_warning() {
 	println('\nIMPORTANT: Make sure to clear your terminal history to avoid leaking this
 access token. Otherwise, regenerate this token as soon as possible. Also,
-consider storing the credentials in a .env file instead. Refer to the
+consider storing the credentials in a .toml file instead. Refer to the
 README.md for more instructions.\n')
 }
 

--- a/enums.v
+++ b/enums.v
@@ -1,10 +1,5 @@
 module main
 
-enum Provider {
-	github
-	gitea
-}
-
 enum Action {
 	list
 	clone

--- a/git/commands.v
+++ b/git/commands.v
@@ -43,7 +43,9 @@ pub fn pull_repository(repository common.Repository, verbose bool) ! {
 	if verbose {
 		print('Check if pull is needed for repository: ${repository.repo_name} ...')
 	}
-	result := os.execute_or_panic('cd ${repository.repo_name} && git remote update && git status')
+
+	_ := os.execute_or_panic('git -C ${repository.repo_name} remote update')
+	result := os.execute_or_panic('git -C ${repository.repo_name} status')
 	if result.output.contains('Your branch is up to date with ') {
 		if verbose {
 			println(' No pull is needed.')
@@ -53,7 +55,7 @@ pub fn pull_repository(repository common.Repository, verbose bool) ! {
 	if verbose {
 		print('Pulling repository: ${repository.repo_name} ...')
 	}
-	os.execute_or_panic('cd ${repository.repo_name} && git pull')
+	os.execute_or_panic('git -C ${repository.repo_name} pull')
 	if verbose {
 		println(' Done.')
 	}

--- a/gitea/gitea.v
+++ b/gitea/gitea.v
@@ -5,7 +5,7 @@ import net.http
 import x.json2
 import time
 
-fn get_data_for_page_number(page int, credentials common.Credentials) ![]common.Repository {
+fn get_data_for_page_number(page int, credentials common.Credential) ![]common.Repository {
 	mut request := http.Request{
 		url: 'https://${credentials.base_url}/api/v1/users/${credentials.username}/repos?page=${page}&limit=100&access_token=${credentials.access_token}'
 		method: .get
@@ -17,7 +17,7 @@ fn get_data_for_page_number(page int, credentials common.Credentials) ![]common.
 	return repositories
 }
 
-pub fn get_repositories(credentials common.Credentials) ![]common.Repository {
+pub fn get_repositories(credentials common.Credential) ![]common.Repository {
 	mut repositories := get_data_for_page_number(1, credentials)!
 
 	for page in 2 .. common.max_page_limit {

--- a/github/github.v
+++ b/github/github.v
@@ -5,7 +5,7 @@ import net.http
 import x.json2
 import time
 
-fn get_data_for_page_number(page int, credentials common.Credentials) ![]common.Repository {
+fn get_data_for_page_number(page int, credentials common.Credential) ![]common.Repository {
 	mut request := http.Request{
 		url: 'https://api.github.com/search/repositories?q=user:${credentials.username}&page=${page}&per_page=100'
 		method: .get
@@ -20,7 +20,7 @@ fn get_data_for_page_number(page int, credentials common.Credentials) ![]common.
 	return repositories
 }
 
-pub fn get_repositories(credentials common.Credentials) ![]common.Repository {
+pub fn get_repositories(credentials common.Credential) ![]common.Repository {
 	mut repositories := get_data_for_page_number(1, credentials)!
 
 	for page in 2 .. common.max_page_limit {

--- a/klonol.v
+++ b/klonol.v
@@ -31,7 +31,6 @@ fn main() {
 		exit(1)
 	}
 
-
 	provider := match provider_str {
 		'github' {
 			Provider.github

--- a/klonol.v
+++ b/klonol.v
@@ -14,8 +14,9 @@ fn main() {
 	fp.description('${description}\n${instructions}')
 	fp.skip_executable()
 
-	provider_str := fp.string('provider', `p`, 'github', 'git provider to use').to_lower()
-	action_str := fp.string('action', `a`, 'list', 'action to perform').to_lower()
+	provider_str := fp.string('provider', `p`, 'github', 'git provider to use (default is github)').to_lower()
+	credentials_path := fp.string('credentials', `c`, 'credentials.toml', 'path to credentials.toml file (default is ./credentials.toml)').to_lower()
+	action_str := fp.string('action', `a`, 'list', 'action to perform [list, clone, pull] ').to_lower()
 	verbose := fp.bool('verbose', `v`, false, 'enable verbose output')
 
 	additional_args := fp.finalize() or {
@@ -29,6 +30,7 @@ fn main() {
 		eprintln(fp.usage())
 		exit(1)
 	}
+
 
 	provider := match provider_str {
 		'github' {
@@ -64,7 +66,7 @@ fn main() {
 		exit(1)
 	}
 
-	credentials := get_credentials_for(provider)!
+	credentials := get_credentials_for(provider, credentials_path)!
 
 	if !git.can_use_ssh(credentials.base_url) {
 		eprintln('Please setup an SSH Key pair and add the public key to your remote Git server.')

--- a/klonol.v
+++ b/klonol.v
@@ -1,9 +1,10 @@
 module main
 
-import flag
+import common
 import git
 import gitea
 import github
+import flag
 import os
 
 fn main() {
@@ -33,10 +34,10 @@ fn main() {
 
 	provider := match provider_str {
 		'github' {
-			Provider.github
+			common.Provider.github
 		}
 		'gitea' {
-			Provider.gitea
+			common.Provider.gitea
 		}
 		else {
 			eprintln('Invalid provider: ${provider_str}')
@@ -65,10 +66,14 @@ fn main() {
 		exit(1)
 	}
 
-	credentials := get_credentials_for(provider, credentials_path)!
+	credentials := get_credentials_for(provider, credentials_path) or {
+		eprintln(err)
+		exit(1)
+	}
 
 	if !git.can_use_ssh(credentials.base_url) {
 		eprintln('Please setup an SSH Key pair and add the public key to your remote Git server.')
+		eprintln('Refer to the README for instructions.')
 		exit(1)
 	}
 


### PR DESCRIPTION
implements #1. 

I only started learning V a few days ago so if i've done anything stupid in the code, let me know.

* Can now load credentials from a toml file (credentials.toml in the same directory as klonol.exe by default. Can change with command-line option -c). 
* get_github_credentials() and get_gittea_credentials() have been merged into a single function

# important
I've tested the github features and it's working, but as i'm not familiar with gittea i've encountered issues trying to test it. 
I created an account at http://gittea.dev and generated an access token, but when i try to use it i get the error `The access token is invalid`. I'm not sure what the issue is and i think i'll leave that up to you @hungrybluedev to fix, because i have no idea how to fix it.